### PR TITLE
Bugfixes for alert module triggers

### DIFF
--- a/modules/alerts.lua
+++ b/modules/alerts.lua
@@ -260,7 +260,7 @@ function Alerts:UNIT_AURA(event, unit)
 
 	for name, aura in pairs(self.db[unit].aurasSpells) do
 		if aura then
-			if UnitBuff(unit, name) or UnitDebuff(unit, name) then
+			if AuraUtil.FindAuraByName(name, unit, "HELPFUL|HARMFUL") then
 				self:SetAlert(unit, "aura_" .. name, aura.priority, aura.color)
 			else
 				self:ClearAlert(unit, "aura_" .. name)
@@ -289,7 +289,7 @@ function Alerts:UNIT_SPELLCAST_START(event, unit, lineID, spell)
 	-- we check self.db[unit] and not self.db.base because the option appears only in party mode
 	if unit == "player" and self.db[unit].hideSelfAlert then return end
 
-	local cast = self.db[unit].castsSpells[spell]
+	local cast = self.db[unit].castsSpells[GladiusEx:SafeGetSpellName(spell)]
 	if cast then
 		line_ids[unit] = lineID
 		self:SetAlert(unit, "cast", cast.priority, cast.color)


### PR DESCRIPTION
Some of the functions used in the alert module had not been updated to reflect the changes made to the API in 8.0.1 which resulted in the alerts module not working for aura detection or cast detection.

UnitBuff no longer accepts a spell name parameter, this has been replaced with AuraUtils.FindAuraByName

The parameter passed to the event handler for UNIT_SPELLCAST_START now appears to be a spell ID rather than a name, reusing name getter to resolve this to a key name for comparison.